### PR TITLE
Move storage to protocol

### DIFF
--- a/src/Devices/DAQ/RedPitayaDAQ.jl
+++ b/src/Devices/DAQ/RedPitayaDAQ.jl
@@ -336,17 +336,17 @@ function startProducer(channel::Channel, daq::RedPitayaDAQ, numFrames)
   end
 
   # Start pipeline
-  @info "Pipeline started"
+  @debug "Pipeline started"
   try
     readPipelinedSamples(rpu, startSample, samplesToRead, channel, chunkSize = chunkSize)
   catch e
-    @info "Attempting reconnect to reset pipeline"
+    @debug "Attempting reconnect to reset pipeline"
     daq.rpc = RedPitayaCluster(daq.params.ips)
     masterTrigger(daq.rpc, false)
     daq.rpv = nothing
     rethrow(e)
   end
-  @info "Pipeline finished"
+  @debug "Pipeline finished"
   return endFrame
 end
 

--- a/src/MPIMeasurements.jl
+++ b/src/MPIMeasurements.jl
@@ -61,9 +61,10 @@ include("Scanner.jl")
 include("Utils/Utils.jl")
 include("Devices/Device.jl")
 
+include("Protocols/Storage/Storage.jl") # Defines stuff needed in devices
 include("Devices/Devices.jl")
 include("Protocols/Protocol.jl")
-include("Utils/Storage.jl") # Depends on MPIScanner
+include("Utils/Storage.jl") # Depends on MPIScanner; TODO: Merge with Protocols/Storage?
 include("Utils/Console/Console.jl")
 
 """

--- a/src/Protocols/Protocol.jl
+++ b/src/Protocols/Protocol.jl
@@ -5,7 +5,6 @@ export  Protocol, ProtocolParams, name, description, scanner, params, runProtoco
         ExceptionEvent, IllegaleStateEvent, DatasetStoreStorageRequestEvent, StorageSuccessEvent, StorageRequestEvent,
         OperationSuccessfulEvent, OperationUnsuccessfulEvent, OperationNotSupportedEvent, MultipleChoiceEvent, ChoiceAnswerEvent
 
-
 abstract type ProtocolParams end
 
 export ProtocolState, PS_UNDEFINED, PS_INIT, PS_RUNNING, PS_PAUSED, PS_FINISHED, PS_FAILED

--- a/src/Protocols/Storage/Storage.jl
+++ b/src/Protocols/Storage/Storage.jl
@@ -1,0 +1,109 @@
+abstract type AsyncBuffer end
+abstract type AsyncMeasTyp end
+struct FrameAveragedAsyncMeas <: AsyncMeasTyp end
+struct RegularAsyncMeas <: AsyncMeasTyp end
+# TODO Update
+asyncMeasType(sequence::Sequence) = acqNumFrameAverages(sequence) > 1 ? FrameAveragedAsyncMeas() : RegularAsyncMeas()
+
+mutable struct FrameAverageBuffer
+  buffer::Array{Float32, 4}
+  setIndex::Int
+end
+FrameAverageBuffer(samples, channels, periods, avgFrames) = FrameAverageBuffer(zeros(Float32, samples, channels, periods, avgFrames), 1)
+
+mutable struct SequenceMeasState
+  numFrames::Int
+  nextFrame::Int
+  channel::Union{Channel, Nothing}
+  producer::Union{Task,Nothing}
+  consumer::Union{Task, Nothing}
+  asyncBuffer::AsyncBuffer
+  buffer::Array{Float32,4}
+  avgBuffer::Union{FrameAverageBuffer, Nothing}
+  #temperatures::Matrix{Float64} temps are not implemented atm
+  type::AsyncMeasTyp
+end
+
+#### Scanner Measurement Functions ####
+####  Async version  ####
+SequenceMeasState() = SequenceMeasState(0, 1, nothing, nothing, nothing, DummyAsyncBuffer(nothing), zeros(Float64,0,0,0,0), nothing, RegularAsyncMeas())
+
+function asyncMeasurement(scanner::MPIScanner, sequence::Sequence)
+  prepareAsyncMeasurement(scanner, sequence)
+  scanner.seqMeasState.producer = @tspawnat scanner.generalParams.producerThreadID asyncProducer(scanner.seqMeasState.channel, scanner, sequence)
+  bind(scanner.seqMeasState.channel, scanner.seqMeasState.producer)
+  scanner.seqMeasState.consumer = @tspawnat scanner.generalParams.consumerThreadID asyncConsumer(scanner.seqMeasState.channel, scanner)
+  return scanner.seqMeasState
+end
+
+function prepareAsyncMeasurement(scanner::MPIScanner, sequence::Sequence)
+  daq = getDAQ(scanner)
+  numFrames = acqNumFrames(sequence)
+  rxNumSamplingPoints = rxNumSamplesPerPeriod(sequence)
+  numPeriods = acqNumPeriodsPerFrame(sequence)
+  frameAverage = acqNumFrameAverages(sequence)
+  setup(daq, sequence)
+
+  # Prepare buffering structures
+  @info "Allocating buffer for $numFrames frames"
+  # TODO implement properly with only RxMeasurementChannels
+  buffer = zeros(Float32,rxNumSamplingPoints, length(rxChannels(sequence)),numPeriods,numFrames)
+  #buffer = zeros(Float32,rxNumSamplingPoints,numRxChannelsMeasurement(daq),numPeriods,numFrames)
+  avgBuffer = nothing
+  if frameAverage > 1
+    avgBuffer = FrameAverageBuffer(zeros(Float32, frameAverageBufferSize(daq, frameAverage)), 1)
+  end
+  channel = Channel{channelType(daq)}(32)
+
+  # Prepare measState
+  measState = SequenceMeasState(numFrames, 1, nothing, nothing, nothing, AsyncBuffer(daq), buffer, avgBuffer, asyncMeasType(sequence))
+  measState.channel = channel
+
+  scanner.seqMeasState = measState
+end
+
+function asyncProducer(channel::Channel, scanner::MPIScanner, sequence::Sequence; prepTx = true)
+  su = getSurveillanceUnit(scanner) # Maybe also support multiple SU units?
+  if !isnothing(su)
+    enableACPower(su)
+    # TODO Send expected enable time to SU
+  end
+  robots = getRobots(scanner)
+  for robot in robots
+    disable(robot)
+  end
+
+  try
+    daq = getDAQ(scanner)
+    asyncProducer(channel, daq, sequence, prepTx = prepTx)
+  finally
+    if !isnothing(su)
+      disableACPower(su)
+    end
+    for robot in robots
+      enable(robot)
+    end
+  end
+end
+
+# Default Consumer
+function asyncConsumer(channel::Channel, scanner::MPIScanner)
+  daq = getDAQ(scanner)
+  measState = scanner.seqMeasState
+
+  @info "Consumer start"
+  while isopen(channel) || isready(channel)
+    while isready(channel)
+      chunk = take!(channel)
+      updateAsyncBuffer!(measState.asyncBuffer, chunk)
+      updateFrameBuffer!(measState, daq)
+    end
+    sleep(0.001)
+  end
+  @info "Consumer end"
+
+  # TODO calibTemperatures is not filled in asyncVersion yet, would need own innerAsyncConsumer
+  #if length(measState.temperatures) > 0
+  #  params["calibTemperatures"] = measState.temperatures
+  #end
+end

--- a/src/Scanner.jl
+++ b/src/Scanner.jl
@@ -138,33 +138,6 @@ Base.@kwdef struct MPIScannerGeneral
   protocolThreadID::Int32 = 4
 end
 
-abstract type AsyncBuffer end
-abstract type AsyncMeasTyp end
-struct FrameAveragedAsyncMeas <: AsyncMeasTyp end
-struct RegularAsyncMeas <: AsyncMeasTyp end
-# TODO Update
-asyncMeasType(sequence::Sequence) = acqNumFrameAverages(sequence) > 1 ? FrameAveragedAsyncMeas() : RegularAsyncMeas()
-
-mutable struct FrameAverageBuffer
-  buffer::Array{Float32, 4}
-  setIndex::Int
-end
-FrameAverageBuffer(samples, channels, periods, avgFrames) = FrameAverageBuffer(zeros(Float32, samples, channels, periods, avgFrames), 1)
-
-mutable struct SequenceMeasState
-  numFrames::Int
-  nextFrame::Int
-  channel::Union{Channel, Nothing}
-  producer::Union{Task,Nothing}
-  consumer::Union{Task, Nothing}
-  asyncBuffer::AsyncBuffer
-  buffer::Array{Float32,4}
-  avgBuffer::Union{FrameAverageBuffer, Nothing}
-  #temperatures::Matrix{Float64} temps are not implemented atm
-  type::AsyncMeasTyp
-end
-
-
 """
     $(SIGNATURES)
 
@@ -179,7 +152,6 @@ mutable struct MPIScanner
   generalParams::MPIScannerGeneral
   "Device instances instantiated by the scanner from its configuration."
   devices::Dict{AbstractString, Device}
-  seqMeasState::Union{SequenceMeasState, Nothing}
 
   """
     $(SIGNATURES)
@@ -365,90 +337,6 @@ function MPIFiles.TransferFunction(configdir::AbstractString, name::AbstractStri
 end
 
 MPIFiles.TransferFunction(scanner::MPIScanner) = TransferFunction(configDir(scanner),transferFunction(scanner))
-
-#### Scanner Measurement Functions ####
-####  Async version  ####
-SequenceMeasState() = SequenceMeasState(0, 1, nothing, nothing, nothing, DummyAsyncBuffer(nothing), zeros(Float64,0,0,0,0), nothing, RegularAsyncMeas())
-
-function asyncMeasurement(scanner::MPIScanner, sequence::Sequence)
-  prepareAsyncMeasurement(scanner, sequence)
-  scanner.seqMeasState.producer = @tspawnat scanner.generalParams.producerThreadID asyncProducer(scanner.seqMeasState.channel, scanner, sequence)
-  bind(scanner.seqMeasState.channel, scanner.seqMeasState.producer)
-  scanner.seqMeasState.consumer = @tspawnat scanner.generalParams.consumerThreadID asyncConsumer(scanner.seqMeasState.channel, scanner)
-  return scanner.seqMeasState
-end
-
-function prepareAsyncMeasurement(scanner::MPIScanner, sequence::Sequence)
-  daq = getDAQ(scanner)
-  numFrames = acqNumFrames(sequence)
-  rxNumSamplingPoints = rxNumSamplesPerPeriod(sequence)
-  numPeriods = acqNumPeriodsPerFrame(sequence)
-  frameAverage = acqNumFrameAverages(sequence)
-  setup(daq, sequence)
-
-  # Prepare buffering structures
-  @info "Allocating buffer for $numFrames frames"
-  # TODO implement properly with only RxMeasurementChannels
-  buffer = zeros(Float32,rxNumSamplingPoints, length(rxChannels(sequence)),numPeriods,numFrames)
-  #buffer = zeros(Float32,rxNumSamplingPoints,numRxChannelsMeasurement(daq),numPeriods,numFrames)
-  avgBuffer = nothing
-  if frameAverage > 1
-    avgBuffer = FrameAverageBuffer(zeros(Float32, frameAverageBufferSize(daq, frameAverage)), 1)
-  end
-  channel = Channel{channelType(daq)}(32)
-
-  # Prepare measState
-  measState = SequenceMeasState(numFrames, 1, nothing, nothing, nothing, AsyncBuffer(daq), buffer, avgBuffer, asyncMeasType(sequence))
-  measState.channel = channel
-
-  scanner.seqMeasState = measState
-end
-
-function asyncProducer(channel::Channel, scanner::MPIScanner, sequence::Sequence; prepTx = true)
-  su = getSurveillanceUnit(scanner) # Maybe also support multiple SU units?
-  if !isnothing(su)
-    enableACPower(su)
-    # TODO Send expected enable time to SU
-  end
-  robots = getRobots(scanner)
-  for robot in robots
-    disable(robot)
-  end
-
-  try
-    daq = getDAQ(scanner)
-    asyncProducer(channel, daq, sequence, prepTx = prepTx)
-  finally
-    if !isnothing(su)
-      disableACPower(su)
-    end
-    for robot in robots
-      enable(robot)
-    end
-  end
-end
-
-# Default Consumer
-function asyncConsumer(channel::Channel, scanner::MPIScanner)
-  daq = getDAQ(scanner)
-  measState = scanner.seqMeasState
-
-  @info "Consumer start"
-  while isopen(channel) || isready(channel)
-    while isready(channel)
-      chunk = take!(channel)
-      updateAsyncBuffer!(measState.asyncBuffer, chunk)
-      updateFrameBuffer!(measState, daq)
-    end
-    sleep(0.001)
-  end
-  @info "Consumer end"
-
-  # TODO calibTemperatures is not filled in asyncVersion yet, would need own innerAsyncConsumer
-  #if length(measState.temperatures) > 0
-  #  params["calibTemperatures"] = measState.temperatures
-  #end
-end
 
 #### Protocol ####
 function getProtocolList(scanner::MPIScanner)

--- a/src/Scanner.jl
+++ b/src/Scanner.jl
@@ -182,7 +182,7 @@ mutable struct MPIScanner
     @assert generalParams.name == name "The folder name and the scanner name in the configuration do not match."
     devices = initiateDevices(params["Devices"])
 
-    scanner = new(name, configDir, generalParams, devices, nothing)
+    scanner = new(name, configDir, generalParams, devices)
 
     return scanner
   end


### PR DESCRIPTION
In order to make storage more flexible, I want to move it to the protocol instead of the scanner.

Some comments on the branch: I can't work on this without my REPL mode since the GUI does not work for me in Windows. I can't merge #32 because I need to register PyTinkerforge first (https://github.com/JuliaRegistries/General/pull/55271). Thus, I will make my changes in this branch in order to separate it from my other work. As soon as the above issues are settled and @nHackel approves this PR, we should also be able to merge #32.